### PR TITLE
Add Serialization To Make Parsing GGPK Faster

### DIFF
--- a/LibGGPK/Records/DirectoryRecord.cs
+++ b/LibGGPK/Records/DirectoryRecord.cs
@@ -51,6 +51,16 @@ namespace LibGGPK.Records
             Read(br); 
         }
 
+        public DirectoryRecord(long recordBegin, uint length, byte[] hash, string name, long entriesBegin, List<DirectoryEntry> entries)
+        {
+            RecordBegin = recordBegin;
+            Length = length;
+            Hash = hash;
+            Name = name;
+            EntriesBegin = entriesBegin;
+            Entries = entries;
+        }
+
         /// <summary>
         /// Reads the PDIR record entry from the specified stream
         /// </summary>

--- a/LibGGPK/Records/FileRecord.cs
+++ b/LibGGPK/Records/FileRecord.cs
@@ -132,6 +132,16 @@ namespace LibGGPK.Records
         /// </summary>
         public DirectoryTreeNode ContainingDirectory;
 
+        public FileRecord(long recordBegin, uint length, byte[] hash, string name, long dataBegin, long dataLength)
+        {
+            RecordBegin = recordBegin;
+            Length = length;
+            Hash = hash;
+            Name = name;
+            DataBegin = dataBegin;
+            DataLength = dataLength;
+        }
+
         public FileRecord(uint length, BinaryReader br)
         {
             RecordBegin = br.BaseStream.Position - 8;
@@ -248,7 +258,7 @@ namespace LibGGPK.Records
             {
                 if (Name.Equals("GameObjectRegister"))
                     return DataFormat.Unicode;
-                return KnownFileFormats[Path.GetExtension(Name).ToLower()];
+                return KnownFileFormats.ContainsKey(Path.GetExtension(Name).ToLower()) ? KnownFileFormats[Path.GetExtension(Name).ToLower()] : DataFormat.Unknown;
             }
         }
 

--- a/LibGGPK/Records/GGPKRecord.cs
+++ b/LibGGPK/Records/GGPKRecord.cs
@@ -32,6 +32,13 @@ namespace LibGGPK.Records
             Read(br);
         }
 
+        public GgpkRecord(long recordBegin, uint length, long[] recordOffsets)
+        {
+            RecordBegin = recordBegin;
+            Length = length;
+            RecordOffsets = recordOffsets;
+        }
+
         /// <summary>
         /// Reads the GGPK record entry from the specified stream
         /// </summary>

--- a/VisualGGPK/MainWindow.xaml
+++ b/VisualGGPK/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:Properties="clr-namespace:VisualGGPK.Properties"
         x:Class="VisualGGPK.MainWindow"
         Title="VisualGGPK" 
-        Height="500" Width="1000" 
+        Height="600" Width="1100" 
         Loaded="Window_Loaded" 
         AllowDrop="True" 
         Drop="Window_Drop_1" 
@@ -47,7 +47,7 @@
                 </TreeView.ContextMenu>
             </TreeView>
             <StackPanel Grid.Row="1" >
-                <Button Content="Save" Click="OnSaveClicked" Width ="50"/>
+                <Button x:Name="SaveButton" Content="Save" Click="OnSaveClicked" Width ="50"/>
             </StackPanel>
         </Grid>
 
@@ -73,6 +73,7 @@
                 <Label x:Name="LabelFileHash" Content="{x:Static Properties:Resources.MainWindow_Label_FileHash}"/>
                 <TextBox x:Name="TextBoxHash" Width="100" IsReadOnly="True"/>
                 <CheckBox x:Name="AutoScrollCheckBox" Content="AutoScroll" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="10,0,0,0" IsChecked="True"/>
+                <Button x:Name="SerializeButton" Content="Serialize" Click="OnSerializeClicked" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="10,3,0,0" Width ="65"/>
             </StackPanel>
 
             <!--different viewers for different types of files-->

--- a/VisualGGPK/Properties/Resources.Designer.cs
+++ b/VisualGGPK/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace VisualGGPK.Properties {
     // 類別透過 ResGen 或 Visual Studio 這類工具。
     // 若要加入或移除成員，請編輯您的 .ResX 檔，然後重新執行 ResGen
     // (利用 /str 選項)，或重建您的 VS 專案。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -259,7 +259,7 @@ namespace VisualGGPK.Properties {
         }
         
         /// <summary>
-        ///   查詢類似 GGPK Pack File|*.ggpk 的當地語系化字串。
+        ///   查詢類似 GGPK Pack File|*.ggpk|Records Bin File|*.bin 的當地語系化字串。
         /// </summary>
         public static string Load_GGPK_Filter {
             get {

--- a/VisualGGPK/Properties/Resources.resx
+++ b/VisualGGPK/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Load_GGPK_Filter" xml:space="preserve">
-    <value>GGPK Pack File|*.ggpk</value>
+    <value>GGPK Pack File|*.ggpk|Records Bin File|*.bin</value>
   </data>
   <data name="ReloadGGPK_Failed" xml:space="preserve">
     <value>Failed to read file: {0}</value>


### PR DESCRIPTION
- Add a "Serialize" button in the upper right corner of VisualGGPK.
  It serializes RecordOffsets into a Records.bin file.
  Next time you open VisualGGPK, select Records.bin and then Content.ggpk to deserialize it.
  Note that you cannot use the same Records.bin after you modify Content.ggpk.

  Other programs can do the same thing with SerializeRecords() and DeserializeRecords() in GrindingGearsPackageContainer.

- Disable buttons when ggpk is loading.