### PR TITLE
Fix end of file exception

### DIFF
--- a/LibDat/Types/TypeFactory.cs
+++ b/LibDat/Types/TypeFactory.cs
@@ -31,6 +31,8 @@ namespace LibDat.Types
             {typeof (ulong), s => s.ReadUInt64()},
             {typeof (string), s =>
             {
+                if (s.BaseStream.Position == s.BaseStream.Length)
+                    return "{null}";    //Fix EOFException caused by pointing to the end of the file to express an empty string (or something not yet added?) in some dats
                 var sb = new StringBuilder();
                 char ch;
                 while ((ch = s.ReadChar()) != 0) { sb.Append(ch); }
@@ -54,6 +56,8 @@ namespace LibDat.Types
             {typeof (ulong), (bw, o) => bw.Write((ulong)o)},
             {typeof (string), (bw, o) =>
             {
+                if (bw.BaseStream.Position == bw.BaseStream.Length)
+                    return;
                 foreach (var ch in (string)o)
                 {
                     bw.Write(ch);

--- a/LibDat/Types/TypeFactory64.cs
+++ b/LibDat/Types/TypeFactory64.cs
@@ -43,6 +43,8 @@ namespace LibDat.Types
              },
              {typeof (string), s =>
                 {
+                    if (s.BaseStream.Position == s.BaseStream.Length)
+                        return "{null}";    ////Fix EOFException caused by pointing to the end of the file to express an empty string (or something not yet added?) in some dats
                      var sb = new StringBuilder();
                      char ch;
                      while ((ch = s.ReadChar()) != 0) { sb.Append(ch); }
@@ -77,6 +79,8 @@ namespace LibDat.Types
             },
             {typeof (string), (bw, o) =>
                 {
+                    if (bw.BaseStream.Position == bw.BaseStream.Length)
+                        return;
                     foreach (var ch in (string)o)
                     {
                         bw.Write(ch);


### PR DESCRIPTION
Fix EOFException caused by pointing to the end of the file to express an empty string (or something not yet added?) in some dats
For example: SkillSurgeEffects.dat